### PR TITLE
docs: licences du code, des donnees et des dependances

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2026 oliver254
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -44,10 +44,48 @@ Pas de backend · pas de compte utilisateur · pas de notifications · pas de pr
 > Le choix d'UI est en statut **`Proposé`**, conditionné à un spike de validation :
 > [`docs/adr/ADR-005-stack-maui-blazor-hybrid.md`](docs/adr/ADR-005-stack-maui-blazor-hybrid.md).
 
-## Données et licences
+## Licences
 
-- **Hub'Eau** — Licence Ouverte Etalab · [hubeau.eaufrance.fr](https://hubeau.eaufrance.fr/page/apis)
-- **VigiEau** — Licence Ouverte 2.0 · [vigieau.gouv.fr](https://vigieau.gouv.fr)
-- **IGN Géoplateforme** — Licence Ouverte · OpenStreetMap en repli (ODbL)
+### Le code — MIT
 
-Ces services sont mis à disposition **sans garantie de disponibilité ni de performance**. L'application prévoit un mode dégradé en conséquence.
+Ce dépôt est distribué sous [licence MIT](LICENSE.txt) : réutilisation libre, y compris commerciale et en source fermée, sous réserve de conserver la notice de copyright.
+
+### Les données — Licence Ouverte, attribution obligatoire
+
+**La licence MIT du code ne couvre pas les données.** Les jeux consommés, et l'asset dérivé redistribué dans ce dépôt, restent sous leur propre licence.
+
+| Source | Licence | Obligation |
+|---|---|---|
+| **Hub'Eau** — Office français de la biodiversité · [hubeau.eaufrance.fr](https://hubeau.eaufrance.fr/page/apis) | Licence Ouverte Etalab — version non précisée sur les CGU (*non vérifié*) | Citation de la source et de la date de mise à jour |
+| **VigiEau** — Ministère de la Transition écologique · [vigieau.gouv.fr](https://vigieau.gouv.fr) | Licence Ouverte 2.0 | idem |
+| **IGN Géoplateforme** — fond de carte WMTS | Licence Ouverte | idem |
+| **OpenStreetMap** — fond de carte en repli | **ODbL** | Attribution + *share-alike* sur toute base dérivée |
+
+La **Licence Ouverte 2.0** n'impose **aucun partage à l'identique** : elle autorise explicitement de « créer des "Informations dérivées" » et de « l'exploiter à titre commercial », contre la seule mention de la paternité — « sa source (a minima le nom du « Concédant ») et la date de la dernière mise à jour ». Elle se déclare compatible avec OGL (Royaume-Uni), CC-BY et ODC-BY.
+*Vérifié le 2026-07-30 sur [etalab/licence-ouverte](https://raw.githubusercontent.com/etalab/licence-ouverte/master/LO.md).*
+
+**Conséquence pour ce dépôt** : l'asset de percentiles généré au build ([`ADR-003`](docs/adr/ADR-003-reference-percentiles-en-asset.md)) est une œuvre dérivée de l'historique Hub'Eau. Il **peut** être diffusé dans un dépôt MIT — mais l'obligation d'attribution le suit, et n'est pas éteinte par le `LICENSE.txt`.
+
+**Sur l'ODbL** : l'application met en cache des **tuiles** (*Produced Work*), pas de la donnée OSM. Le code n'est donc pas contaminé. Cela changerait si des géométries OSM étaient un jour extraites et stockées en base (*Derivative Database*).
+⚠️ Cette lecture n'a **pas** été confirmée par relecture du texte ODbL — à vérifier si OSM devient un repli réellement servi en production.
+
+### Les dépendances — toutes permissives
+
+Aucune dépendance sous licence copyleft. BSD-3-Clause et Apache-2.0 ne sont **pas** relicenciées en MIT : leurs notices doivent être conservées et présentées dans l'écran « À propos ».
+
+| Dépendance | Licence |
+|---|---|
+| .NET MAUI · `BlazorWebView` | MIT |
+| **BrilliantMediator 3.0.0** | MIT — *vérifié le 2026-07-30 sur [nuget.org](https://www.nuget.org/packages/BrilliantMediator)* |
+| CommunityToolkit.Mvvm | MIT |
+| `sqlite-net-pcl` | MIT |
+| LiveChartsCore · Chart.js | MIT |
+| Polly | BSD-3-Clause |
+| MapLibre GL JS | BSD-3-Clause |
+| xUnit | Apache-2.0 |
+
+⚠️ Seul `BrilliantMediator` a été vérifié à la source. Les autres lignes sont **à confirmer** à l'ajout effectif du paquet.
+
+### Disponibilité
+
+Les services publics consommés sont mis à disposition **sans garantie de disponibilité ni de performance**, et sans quota chiffré (`C-15`). L'application prévoit un mode dégradé en conséquence.


### PR DESCRIPTION
## Ce que fait cette PR

Deux fichiers, aucun code. Le dépôt annonçait une licence MIT **sans titulaire**, et ne disait rien des licences des données qu'il redistribue.

### `LICENSE.txt`

Les placeholders `[year]` / `[fullname]` du template MIT étaient restés tels quels depuis le commit initial : la licence était sans titulaire nommé. Remplis avec `2026 oliver254`.

> ⚠️ **À arbitrer** — l'identité git du dépôt a été retenue faute de confirmation. Un nom civil ou une entité porteuse serait plus solide juridiquement. Un seul mot à changer.

### `README.md`

La section `## Données et licences` (3 puces) devient `## Licences`, en trois volets : le **code** (MIT), les **données** (4 sources, leur licence, leur obligation), les **dépendances** (8 licences, aucune copyleft).

## Ce qui a été vérifié

Conformément à la règle d'anti-hallucination du projet, chaque fait est daté avec son URL.

| Fait | Source | Date |
|---|---|---|
| **LO 2.0** — aucun partage à l'identique, attribution seule, compatible OGL / CC-BY / ODC-BY | [etalab/licence-ouverte](https://raw.githubusercontent.com/etalab/licence-ouverte/master/LO.md) | 2026-07-30 |
| **BrilliantMediator 3.0.0** — MIT, cible `net10.0` | [nuget.org](https://www.nuget.org/packages/BrilliantMediator) | 2026-07-30 |

Le second levait un doute réel : c'est le paquet qui impose .NET 10 à tout le projet (`ADR-008`), et il est peu diffusé.

## Ce qui n'a PAS été vérifié — et est signalé comme tel dans le fichier

- Les **six autres licences de dépendances** (MAUI, CommunityToolkit.Mvvm, sqlite-net-pcl, LiveCharts, Polly, MapLibre GL JS, xUnit) : indiquées de mémoire, à confirmer à l'ajout effectif du paquet.
- La lecture **ODbL** : le cache de tuiles relève du *Produced Work* et ne contamine donc pas le code. Non confirmé par relecture du texte ODbL.
- La **version** de la Licence Ouverte côté Hub'Eau reste non précisée sur leurs CGU — déjà noté dans `docs/01-analyse.md`.

## Conséquences à retenir

1. L'obligation d'attribution Hub'Eau **suit l'asset percentiles** (`ADR-003`) : elle n'est pas éteinte par le `LICENSE.txt`.
2. L'écran « À propos » (`docs/03-conception.md`) porte désormais une **obligation**, pas une courtoisie : notices BSD-3-Clause / Apache-2.0 en plus des attributions de sources.
3. GPL / AGPL restent écartées : incompatibles en pratique avec la distribution App Store iOS, alors que la cible est iOS + Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)