### PR TITLE
chore: ignore les reglages Claude Code personnels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Claude Code — réglages personnels, propres à la machine et non versionnés
+# (.claude/settings.json, lui, reste versionné : c'est la config d'équipe)
+.claude/settings.local.json


### PR DESCRIPTION
## Contexte

`.claude/settings.local.json` a été créé pour autoriser `gh repo edit`, le temps de basculer le dépôt en **squash-only**. C''est un réglage de confiance propre à une machine, pas une convention de projet.

Or `.gitignore` ne contenait **aucune** entrée `.claude`. Sans cette PR, le fichier serait committé au prochain `git add .` — publiant une autorisation d''exécution dans un dépôt public.

## Le changement

Une seule ligne ignorée, volontairement précise plutôt que `.claude/` en bloc :

| Fichier | Versionné ? | Rôle |
|---|---|---|
| `.claude/settings.json` | **oui** | configuration d''équipe, si le projet en adopte une un jour |
| `.claude/settings.local.json` | **non** | réglages personnels, propres à la machine |

## Vérification

`git check-ignore -v .claude/settings.local.json` renvoie `.gitignore:367`, et `.claude/` a disparu des fichiers non suivis de `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)