### PR TITLE
fix(ci): forcer uuid >= 11.1.1 sous xcode (CVE-2026-41907)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10575,13 +10575,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "react": "19.2.3",
     "react-native": "0.86.2"
   },
+  "overrides": {
+    "xcode": {
+      "uuid": "^11.1.1"
+    }
+  },
   "devDependencies": {
     "@types/jest": "29.5.14",
     "@types/react": "~19.2.2",


### PR DESCRIPTION
Dependabot échouait en boucle sur l'alerte de sécurité #1, avec security_update_not_possible : la chaîne expo -> @expo/config-plugins -> xcode@3.0.1 épingle uuid en "^7.0.3", et aucune version publiée de xcode ne relâche ce caret (3.0.1 est la dernière stable, les nightlies 3.0.2 aussi). Aucun chemin de mise à jour n'existe en amont.

L'override npm résout uuid en 11.1.1, sous xcode uniquement.

Pourquoi la 11 et pas la 14 : xcode fait require('uuid') en CJS, or uuid@14 est ESM pur ("type": "module", pas de "main") et ne se require que sous Node >= 22.12. npm déprécie d'ailleurs uuid <= 10 avec la consigne explicite « For CommonJS codebases, use uuid@11 ».

Vérifié : xcode.generateUuid() rend toujours 24 caractères hex, @expo/config-plugins se charge, npm run verify vert (164 tests).