### PR TITLE
ci: placer setup-java après le prebuild, sinon son cache n'a rien à i…

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -33,12 +33,6 @@ jobs:
           node-version: 24
           cache: npm
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: gradle
-
       - name: Installer les dépendances
         run: npm ci
 
@@ -112,6 +106,23 @@ jobs:
 
       - name: Générer le projet natif
         run: npx expo prebuild --platform android --clean --no-install
+
+      # ⚠️ `setup-java` vient **après** le prebuild, et ce n'est pas cosmétique.
+      # Son `cache: gradle` calcule sa clé en cherchant des fichiers Gradle dans
+      # l'arbre de travail ; or `/android` est dans .gitignore — il n'existe pas
+      # au checkout, il naît du prebuild. Placée avant, l'étape échouait, et le
+      # job avec elle :
+      #
+      #   Error: No file in /home/runner/work/MartinPecheur/MartinPecheur
+      #   matched to [**/*.gradle*, **/gradle-wrapper.properties, ...]
+      #
+      # Rien entre le checkout et ici n'a besoin d'un JDK : npm ci, la
+      # vérification, les trois garde-fous et le prebuild sont tous en Node.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
 
       # Le keystore n'existe que le temps du job, hors du dépôt (.gitignore
       # couvre déjà *.jks et *.key). Il arrive en base64 pour traverser

--- a/docs/guide-release.md
+++ b/docs/guide-release.md
@@ -231,7 +231,10 @@ produite. La prochaine sera donc `v0.1.0-alpha.1`.
 ## Voie B — release par GitHub Actions
 
 ✅ **Posé le 2026-08-15 :** [`.github/workflows/release-android.yml`](../.github/workflows/release-android.yml).
-🔄 **Jamais déclenché** — ni par un tag, ni à la main. Rien de ce qui suit n'est constaté.
+🚨 **Déclenché deux fois le 2026-08-15, échoué deux fois** — par le tag `v0.1.0`, puis par un
+`workflow_dispatch` sur `dev`. Même erreur les deux fois, à la **troisième étape**, avant même
+`npm ci` (voir l'encadré ci-dessous). **La CI n'a encore produit aucun APK** : au-delà du *checkout*
+et de `setup-node`, rien de ce qui suit n'est constaté.
 
 L'intérêt dépasse le confort. Le *runner* `ubuntu-latest` porte un SDK Android sur un chemin sans
 espace ni parenthèse, donc **toute la saga du NDK décrite au
@@ -240,6 +243,20 @@ disparaît** — et le **piège n° 2 ci-dessus avec elle**, puisque le `ANDROID
 sur un SDK complet et inscriptible. Le passage par la CI est donc, sur ce projet, plus fiable que le
 build local. Et `prebuild --clean` y transforme le caractère volatil d'`android/` en propriété : le
 natif est reconstruit de zéro à chaque fois, donc reproductible.
+
+> 🚨 **Constaté le 2026-08-15 : `setup-java` ne peut pas se placer avant le prebuild.**
+> Son `cache: gradle` calcule sa clé de cache en cherchant des fichiers Gradle dans l'arbre de
+> travail. Or `/android` est dans le `.gitignore` : au *checkout*, il n'existe pas.
+>
+> ```
+> Error: No file in /home/runner/work/MartinPecheur/MartinPecheur matched to
+> [**/*.gradle*, **/gradle-wrapper.properties, ...]
+> ```
+>
+> L'étape est donc placée **après** `expo prebuild`, qui fait naître `android/build.gradle`,
+> `android/app/build.gradle`, `android/settings.gradle` et `gradle/wrapper/gradle-wrapper.properties`.
+> Rien avant elle n'a besoin d'un JDK : `npm ci`, la vérification, les garde-fous et le prebuild
+> lui-même sont tous en Node. **Corrigé le 2026-08-15, pas encore éprouvé.**
 
 **Deux déclencheurs :** un tag `v*` construit **et publie** ; un `workflow_dispatch` construit
 **sans rien publier** et dépose l'APK en artefact — c'est ainsi qu'on éprouve la chaîne sans


### PR DESCRIPTION
…ndexer

Les deux déclenchements du 2026-08-15 — tag v0.1.0 (run 31883693985) puis workflow_dispatch sur dev (run 31884547803) — ont échoué à la troisième étape, avant même npm ci, sur la même erreur :

  Error: No file in /home/runner/work/MartinPecheur/MartinPecheur
  matched to [**/*.gradle*, **/gradle-wrapper.properties, ...]

actions/setup-java avec `cache: gradle` calcule sa clé de cache en cherchant des fichiers Gradle dans l'arbre de travail. Or /android est dans le .gitignore : au checkout il n'existe pas, il naît du prebuild.

L'étape passe donc après `expo prebuild`, qui produit bien les quatre fichiers du glob (build.gradle, app/build.gradle, settings.gradle, gradle/wrapper/gradle-wrapper.properties — vérifié sur l'arbre local). Rien avant elle n'a besoin d'un JDK : npm ci, la vérification, les trois garde-fous et le prebuild sont tous en Node. Bénéfice de bord : sur un tag, les garde-fous s'arment maintenant avant qu'on installe un JDK et restaure un cache.

docs/guide-release.md disait « Jamais déclenché […] rien de ce qui suit n'est constaté » — c'est devenu faux. Corrigé, et le piège consigné.

Non éprouvé : le workflow_dispatch n'est accepté que depuis la branche par défaut, ce correctif ne peut donc être vérifié qu'une fois sur dev.